### PR TITLE
Add in the `public $context` property to the stream wrapper.

### DIFF
--- a/src/FlysystemStreamWrapper.php
+++ b/src/FlysystemStreamWrapper.php
@@ -26,6 +26,13 @@ class FlysystemStreamWrapper
     const STREAM_URL_IGNORE_SIZE = 8;
 
     /**
+     * PHP-passed stream context.
+     *
+     * @var resource|null
+     */
+    public $context;
+
+    /**
      * The registered filesystems.
      *
      * @var \League\Flysystem\FilesystemInterface[]


### PR DESCRIPTION
I believe this should fix #27 

Got here via [`drupal/flysystem`](https://www.drupal.org/project/flysystem/issues/3387094).

It looks like [the property](https://www.php.net/manual/en/class.streamwrapper.php#streamwrapper.props.context) should have been there for a _long_ time (as in, added in PHP 5 days, according to the [wayback machine](http://web.archive.org/web/20150814000527/http://php.net/manual/en/class.streamwrapper.php)), and is only being exposed now with the bump to PHP 8.2 being more strict with dynamic properties?